### PR TITLE
Auth & MainControllerTest 속성 수정

### DIFF
--- a/src/test/java/com/ggamangso/boardproject/controller/AuthControllerTest.java
+++ b/src/test/java/com/ggamangso/boardproject/controller/AuthControllerTest.java
@@ -2,25 +2,35 @@ package com.ggamangso.boardproject.controller;
 
 
 import com.ggamangso.boardproject.config.SecurityConfig;
+import com.ggamangso.boardproject.config.TestSecurityConfig;
+import com.ggamangso.boardproject.service.ArticleService;
+import com.ggamangso.boardproject.service.PaginationService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestComponent;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 
+import static org.mockito.BDDMockito.then;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @DisplayName("View 컨트롤러 - 로그인")
-@Import(SecurityConfig.class)
-@WebMvcTest(Void.class)
+@Import(TestSecurityConfig.class)
+@WebMvcTest(AuthControllerTest.EmptyController.class)
 public class AuthControllerTest {
 
     private final MockMvc mvc;
+
+    @MockBean private ArticleService articleService;
+    @MockBean private PaginationService paginationService;
+
 
     public AuthControllerTest(@Autowired MockMvc mvc) {
         this.mvc = mvc;
@@ -35,8 +45,14 @@ public class AuthControllerTest {
         //When & Then
         mvc.perform(get("/login"))
                 .andExpect(status().isOk()) // 상태가 Ok 인지
-                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
-                .andDo(MockMvcResultHandlers.print());
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML));
+        then(articleService).shouldHaveNoInteractions();
+        then(paginationService).shouldHaveNoInteractions();
+
+    }
+
+    @TestComponent
+    static class EmptyController{
 
     }
 }

--- a/src/test/java/com/ggamangso/boardproject/controller/MainControllerTest.java
+++ b/src/test/java/com/ggamangso/boardproject/controller/MainControllerTest.java
@@ -1,6 +1,7 @@
 package com.ggamangso.boardproject.controller;
 
 import com.ggamangso.boardproject.config.SecurityConfig;
+import com.ggamangso.boardproject.config.TestSecurityConfig;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,7 +13,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@Import(SecurityConfig.class)
+@Import(TestSecurityConfig.class)
 @WebMvcTest(MainController.class)
 class MainControllerTest {
 


### PR DESCRIPTION
 Test할 수 있는 유저정보를 넣어주는 기능을 포함한 TestSecurityConfig 로 변경 및 테스트 일부 수정
AuthControllerTest에서
webMvcTest 빈으로 넣어준 Void.class는 적절하지 않기 때문에 테스트용 빈 클래스는 말들어 주입해줌.